### PR TITLE
fix: Remove unwanted trailing slash when resolving href in hash mode

### DIFF
--- a/src/lib/utils/navigation.utils.ts
+++ b/src/lib/utils/navigation.utils.ts
@@ -85,9 +85,9 @@ export function resolveNewHref(target: string, {
     const strSearch = search.toString();
     if (strSearch) href.hash += `?${strSearch}`;
     if (trailingHash?.length && !stripTrailingHash) href.hash += `#${trailingHash}`;
-    if (base) href.pathname = toPathSegment(base, true);
+    if (base) href.pathname = toPathSegment(base, false);
     if (href.search && !href.search?.endsWith('/')) href.search += '/';
-    if (!href.search?.length && !href.pathname?.endsWith('/')) href.pathname += '/';
+    // if (!href.search?.length && !href.pathname?.endsWith('/')) href.pathname += '/';
   } else {
     href.pathname = [base, _target]
       .filter(Boolean)


### PR DESCRIPTION
In hash mode, `resolveNewHref()` adds a trailing slash to the URL's pathname to avoid ambiguity between path segments and query strings like this:
`chrome-extension://<ext_id>/popup.html/#/settings-page`
But in Chrome extensions—where resources like `popup.html` live under the `chrome-extension://` protocol—a trailing slash in the pathname causes Chrome to treat it as a request for a directory rather than a file, when the user inputs this URL directly in their address bar. This shows them a "Your file couldn't be accessed" error.

We need to instead resolve it to this:
`chrome-extension://<ext_id>/popup.html#/settings-page`
When a user directly inputs this in their address bar, the browser correctly opens the `popup.html` file and the router correctly routes us to the `/settings-page` as expected.